### PR TITLE
iOS Fix for Non-GET Requests

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-webview-utils",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Add custom headers to a NativeScript WebView. Perhaps more utils later.",
   "main": "webview-utils",
   "typings": "index.d.ts",

--- a/src/webview-utils.ios.ts
+++ b/src/webview-utils.ios.ts
@@ -27,14 +27,14 @@ class WebviewUtilsWKNavigationDelegateImpl extends NSObject implements WKNavigat
     });
 
     if (isHttpRequest && !areHeadersAdded) {
-      if (navigationAction.request.HTTPMethod !== 'GET' || this.headers.length) {
+      if (navigationAction.request.HTTPMethod !== 'GET') {
         decisionHandler(WKNavigationActionPolicy.Allow);
         return;
       }
 
       decisionHandler(WKNavigationActionPolicy.Cancel);
       
-      const customRequest = navigationAction.request;
+      const customRequest = navigationAction.request.mutableCopy();
 
       // add the original headers
       for (let i = 0; i < navigationAction.request.allHTTPHeaderFields.count; i++) {

--- a/src/webview-utils.ios.ts
+++ b/src/webview-utils.ios.ts
@@ -27,12 +27,14 @@ class WebviewUtilsWKNavigationDelegateImpl extends NSObject implements WKNavigat
     });
 
     if (isHttpRequest && !areHeadersAdded) {
+      if (navigationAction.request.HTTPMethod !== 'GET' || this.headers.length) {
+        decisionHandler(WKNavigationActionPolicy.Allow);
+        return;
+      }
+
       decisionHandler(WKNavigationActionPolicy.Cancel);
-      const customRequest = new NSMutableURLRequest({
-        URL: navigationAction.request.URL,
-        cachePolicy: NSURLRequestCachePolicy.UseProtocolCachePolicy,
-        timeoutInterval: 60
-      });
+      
+      const customRequest = navigationAction.request;
 
       // add the original headers
       for (let i = 0; i < navigationAction.request.allHTTPHeaderFields.count; i++) {


### PR DESCRIPTION
Hi There,

This is a fix for the iOS issue regarding POST (or other) request types with custom header data. I've verified this works on iOS 11+ devices, but haven't been able to test with older version.